### PR TITLE
Export all TypeScript and Flow types from definitions.{js|d.ts}

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,9 @@
 import * as graphql from 'graphql';
 
 export { graphql };
+
+export * from './definition';
+
 export { default as TypeComposer } from './typeComposer';
 export { default as InputTypeComposer } from './inputTypeComposer';
 export { default as Resolver } from './resolver';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,6 +2,9 @@
 import * as graphql from 'graphql';
 
 export { graphql };
+
+export * from './definition';
+
 export { default as TypeComposer } from './typeComposer';
 export { default as InputTypeComposer } from './inputTypeComposer';
 export { default as Resolver } from './resolver';


### PR DESCRIPTION
As discussed in #82.

I'm not sure for the Flow export, I've seen that in Flow the syntax is `export type { SomeType }` whereas in typescript we would do `export { SomeType }` like a JS value. I hope the `export * from` syntax in Flow also exports types?