### PR TITLE
fix(example) with-graphql-tools launch on wrong port number

### DIFF
--- a/examples/with-graphql-tools/README.md
+++ b/examples/with-graphql-tools/README.md
@@ -6,5 +6,5 @@ after Apollo team release new version of graphql-tools, we can merge our schema 
 ```
 npm i
 node index.js
-// go to http://localhost:3000/graphqi
+// go to http://localhost:3000/graphiql
 ```

--- a/examples/with-graphql-tools/index.js
+++ b/examples/with-graphql-tools/index.js
@@ -9,4 +9,4 @@ server.use('/graphql', graphqlExpress((req) => ({
   schema
 })))
 
-server.listen(3001, function () { console.log('app launch on 3000') })
+server.listen(3000, function () { console.log('app launch on 3000') })


### PR DESCRIPTION
I just notice that example use 3001 instead of 3000 that tell in console 😐